### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gaduhistory (0.5-5) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:30:54 +0100
+
 gaduhistory (0.5-4) unstable; urgency=low
 
   * Orphaning.

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Debian QA Group <packages@qa.debian.org>
 Build-Depends: debhelper (>= 7.0.50~), python (>= 2.6.6-3~)
 Standards-Version: 3.9.5
 Homepage: https://github.com/socek/Gadu-History
-Vcs-Git: git://github.com/porridge/gaduhistory.git -b debian
+Vcs-Git: https://github.com/porridge/gaduhistory.git -b debian
 
 Package: gaduhistory
 Architecture: all


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
